### PR TITLE
Fix key error

### DIFF
--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -626,7 +626,7 @@ class InstructionTranslatorBase(fx.Tracer):
         name = inst.argval
         options = VariableTracker.propagate([obj])
         if isinstance(obj, NNModuleVariable):
-            key = f"{obj.module_key}.{name}"
+            key = f"{obj.module_key}_{name}_{i}"
             subobj = self.get_submodule(key)
             if isinstance(subobj, torch.Tensor):
                 self.push(


### PR DESCRIPTION
In #2, the key contained several "atoms" (that is, two prefixes and a field). This caused the list itself to be searched for the field in `get_submodule`, while we needed the `nn_modules` dict to be searched. To fix this, this PR removes "."s from the key to flatten it.