### PR TITLE
Support instances of user-defined, non-`nn.Module` classes

### DIFF
--- a/torchdynamo/variable_tracker.py
+++ b/torchdynamo/variable_tracker.py
@@ -295,6 +295,23 @@ class UserMethodVariable(UserFunctionVariable):
         return types.MethodType
 
 
+class UserClassInstanceVariable(VariableTracker):
+    """Some object created from a user-defined class"""
+
+    def __init__(self, value, **kwargs):
+        super(UserClassInstanceVariable, self).__init__(**kwargs)
+        self.value = value
+
+    def as_proxy(self):
+        return self.value
+
+    def python_type(self):
+        return type(self.value)
+
+    def python_value(self):
+        return self.value
+
+
 class AllowedFunctionOrModuleVariable(VariableTracker):
     """Points to a module or method in torch.*"""
 


### PR DESCRIPTION
This PR is a starting-off point for supporting all user-defined classes in torchdynamo. 

Big TODOs for later:
- Allow user-defined subclasses of `nn.Module` to be inlined
- Support user-defined, non-`nn.Module` classes that use an `nn.Module` (not sure if this is worth implementing; can't see anyone doing this in real life)