### PR TITLE
fx2trt_lower

### DIFF
--- a/torchbench.py
+++ b/torchbench.py
@@ -275,6 +275,12 @@ def speedup_experiment_trt(speedups, args, model, example_inputs):
             m_fx2trt = fx2trt(model, example_inputs)
     except Exception:
         log.exception("fx2trt")
+    
+    m_fx2trt_lower = None
+    try:
+        m_fx2trt_lower = fx2trt_lower(model, example_inputs)
+    except Exception:
+        log.exception("fx2trt_lower")
 
     return baselines(
         [
@@ -282,6 +288,7 @@ def speedup_experiment_trt(speedups, args, model, example_inputs):
             ("onnx2trt", m_onnx2trt),
             ("torch2trt", m_torch2trt),
             ("fx2trt", m_fx2trt),
+            ("fx2trt_lower", m_fx2trt_lower),	
         ],
         example_inputs,
         args,

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -182,6 +182,21 @@ def fx2trt(model, inputs):
 
 
 @catch_errors
+def fx2trt_lower(model, inputs):
+    from torch.fx.experimental.fx2trt.lower import Lowerer
+    from torch.fx.experimental.fx2trt import LowerSetting
+
+    lower_setting = LowerSetting()
+    lower = Lowerer.create(lower_setting=lower_setting)
+    output = lower(model, inputs)
+    model = acc_tracer.trace(model, inputs)
+    
+    if isinstance(outputs, (tuple, list)) and len(outputs) == 1:
+        return lambda *args: (trt_mod(*args),)
+    return trt_mod
+
+
+@catch_errors
 def torch2trt(model, inputs):
     from torch2trt import torch2trt
 


### PR DESCRIPTION
User lower.py instead of fx2trt to perform lower to TensorRT work.

Current local run error:
shirong@shirong-mbp torchdynamo % ./torchbench.py -d cuda --speedup-trt -n 200 --no-skip
  File "./torchbench.py", line 67
    return name if len(name) <= limit else f"{name[:limit - 3].rstrip('_')}..."
                                                                              ^
SyntaxError: invalid syntax