### PR TITLE
[Doc] Fix a miner issus in setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ cd ..
 git clone git@github.com:jansel/torchdynamo.git
 cd torchdynamo
 conda activate torchbenchmark
+pip3 install torch tabulate
 make setup
 python setup.py develop  # compiles C/C++ extension
 pytest  # run tests


### PR DESCRIPTION
I recently started to play with TorchDynamo, and found an issue when setting up the conda environment following the instructions in README. Specifically, the conda environment setup by the torchbenchmark script doesn't include PyTorch and tabulate. Missing PyTorch results in a failure in `python setup.py develop`, and missing tabulate fails almost all test cases when running `make test`.

cc @jansel 