### PR TITLE
[Backend][TVM] Support boolean as output's dtype

### DIFF
--- a/torchdynamo/bytecode_analysis.py
+++ b/torchdynamo/bytecode_analysis.py
@@ -24,7 +24,6 @@ if sys.version_info < (3, 8):
             return 0
         return dis.stack_effect(opcode, arg)
 
-
 else:
     stack_effect = dis.stack_effect
 


### PR DESCRIPTION
This PR helps the TVM backend to work with boolean output. The current issue is `from_dlpack` would complain converting a boolean type tensor: `RuntimeError: Unsupported kUInt bits 1`. Since this is an issue in PyTorch, this PR uses a workaround that leverages numpy for conversion, although this introduces data copy overhead.

Meanwhile, this is the script I used for testing. The boolean output comes from `lt`, so this happens for all target functions with if-statement.

```python
import torch
import torchdynamo
from torchdynamo.optimizations import backends

def compiler_fn(graph, example_inputs):
    return backends.BACKENDS["tvm"](graph, example_inputs)

def fn(a, b):
    x = a + b
    x = x / 2.0
    if x.sum() < 0.0:
        return x * -1.0
    return x

with torchdynamo.optimize(compiler_fn):
    print(fn(torch.randn(10), torch.randn(10)))
```

cc @jansel 